### PR TITLE
completer | dbmetadata: All calls to ODBC/SQL migrated away from completer

### DIFF
--- a/odbcli/app.py
+++ b/odbcli/app.py
@@ -87,7 +87,8 @@ class sqlApp:
         # Loop over side-bar when moving past the element on the bottom
         self.obj_list[len(self.obj_list) - 1].next_object = self.obj_list[0]
         self._selected_object = self.obj_list[0]
-        self.completer = MssqlCompleter(smart_completion = True, get_conn = lambda: self.active_conn)
+        self.completer = MssqlCompleter(smart_completion = True,
+                get_conn = lambda: self.active_conn)
 
         self.application = self._create_application()
 

--- a/odbcli/conn.py
+++ b/odbcli/conn.py
@@ -38,7 +38,7 @@ class sqlConnection:
         self.username = username
         self.password = password
         self.logger = getLogger(__name__)
-        self.dbmetadata = DbMetadata()
+        self.dbmetadata = DbMetadata(self)
         self._quotechar = None
         self._search_escapechar = None
         self._search_escapepattern = None
@@ -450,8 +450,12 @@ class sqlConnection:
 
     def current_catalog(self) -> str:
         if self.conn.connected():
-            return self.conn.catalog_name
-        return None
+            with self._lock:
+                res = self.conn.catalog_name
+        else:
+            res = None
+
+        return res
 
     def connected(self) -> bool:
         return self.conn.connected()

--- a/odbcli/dbmetadata.py
+++ b/odbcli/dbmetadata.py
@@ -1,16 +1,55 @@
 from threading import Lock, Event, Thread
 
 class DbMetadata():
-    def __init__(self) -> None:
+    """
+        Internal representation of a database.  The structure is that of a nested
+        dictionary, with the top nodes being "table", "view", "function", and
+        "datatype".   From there the structure is:
+        "table" = {..., "catalog.lower" = (catalog, {...., "schema".lower = (...)})
+        Some notes:
+          * All identifiers (catalog, schema, table, column) are quoted using
+          the quoting character for the connection.
+          * The name of a node is *.lower to allow for case insensitive search
+          through the connection metadata.
+    """
+    def __init__(self, conn: "sqlConnection") -> None:
+        self._conn = conn
         self._lock = Lock()
         self._dbmetadata = {'table': {}, 'view': {}, 'function': {},
                 'datatype': {}}
 
+    def escape_name(self, name):
+        if self._conn.connected():
+            name = self._conn.escape_name(name)
+
+        return name
+
+    def escape_names(self, names):
+        if self._conn.connected():
+            names = self._conn.escape_names(names)
+
+        return names
+
+    def unescape_name(self, name):
+        """ Unquote a string."""
+        if self._conn.connected():
+            name = self._conn.unescape_name(name)
+        return name
+
+    def current_catalog(self):
+        if self._conn.connected():
+            return self._conn.current_catalog()
+
+        return None
+
     def extend_catalogs(self, names: list) -> None:
-        with self._lock:
-            for metadata in self._dbmetadata.values():
-                for catalog in names:
-                    metadata[catalog.lower()] = (catalog, {})
+        if len(names):
+            # Add "" catalog to house tables without catalog / schema
+            names.append("")
+            with self._lock:
+                for metadata in self._dbmetadata.values():
+                    for catalog in names:
+                        metadata[catalog.lower()] = (catalog, {})
         return
 
     def get_catalogs(self, obj_type: str = "table", cased: bool = True) -> list:
@@ -23,9 +62,11 @@ class DbMetadata():
             else:
                 res = list(self._dbmetadata[obj_type].keys())
 
-
-        if len(res) == 0:
-            return None
+        if len(res) == 0 and self._conn.connected():
+            res = self.escape_names(self._conn.list_catalogs())
+            self.extend_catalogs(res)
+            # TODO: Should we recursively call get_catalogs here so as to be
+            # able to respect the cased argument?
 
         return res
 
@@ -37,6 +78,8 @@ class DbMetadata():
         catlower = catalog.lower()
         cat_cased = catalog
         if len(names):
+            # Add "" schema to house tables without schema
+            names.append("")
             with self._lock:
                 for metadata in self._dbmetadata.values():
                     # Preserve casing if an entry already there
@@ -45,6 +88,15 @@ class DbMetadata():
                     metadata[catlower] = (cat_cased, {})
                     for schema in names:
                         metadata[catlower][1][schema.lower()] = (schema, {})
+        # If we passed nothing then take out that element entirely out
+        # of the dict
+        else:
+            with self._lock:
+                for otype in self._dbmetadata.keys():
+                    try:
+                        del self._dbmetadata[otype][catlower]
+                    except KeyError:
+                        pass
         return
 
     def get_schemas(self, catalog: str, obj_type: str = "table", cased: bool = True) -> list:
@@ -64,6 +116,26 @@ class DbMetadata():
             else:
                 res = list(self._dbmetadata[obj_type][catlower][1].keys())
 
+        if len(res) == 0 and self._conn.connected():
+            # Looking for schemas in a specified catalog
+            res_u = []
+            catalog_u = self.unescape_name(catalog)
+            # Attempt list_schemas
+            res_u = self._conn.list_schemas(
+                    catalog = self._conn.sanitize_search_string(catalog_u))
+
+            if len(res_u) < 1:
+                res_u = self._conn.find_tables(
+                        catalog = self._conn.sanitize_search_string(catalog_u),
+                        schema = "",
+                        table = "",
+                        type = "")
+                res_u = [r.schema for r in res_u]
+
+            res = self.escape_names(res_u)
+            self.extend_schemas(catalog = catalog, names = res)
+            # TODO: Should we recursively call get_schemas here so as to be
+            # able to respect the cased argument?
 
         return res
 
@@ -84,11 +156,14 @@ class DbMetadata():
         # of the dict
         else:
             with self._lock:
-                del self._dbmetadata[obj_type][catlower][1][schlower]
+                try:
+                    del self._dbmetadata[obj_type][catlower][1][schlower]
+                except KeyError:
+                    pass
 
         return
 
-    def get_objects(self, catalog: str, schema: str, obj_type: str = "table") -> list:
+    def get_objects(self, catalog: str, schema: str, obj_type: str = "table", cased: bool = True) -> list:
         """ Retrieve objects as the keys for _dbmetadata[obj_type][catalog][schema]
             If catalog is not part of the _dbmetadata[obj_type] keys, or schema
             not one of the keys in _dbmetadata[obj_type][catalog] will return None
@@ -97,13 +172,108 @@ class DbMetadata():
         catlower = catalog.lower()
         schlower = schema.lower()
         schemas = self.get_schemas(catalog = catalog, obj_type = obj_type, cased = False)
-        if schemas is None or schlower not in schemas:
+        if (schemas is None or schlower not in schemas):
             return None
 
+        res = []
         with self._lock:
-            res = [casedkey for casedkey, mappedvalue in self._dbmetadata[obj_type][catlower][1][schlower][1].values()]
+            if cased:
+                res = [casedkey for casedkey, mappedvalue in self._dbmetadata[obj_type][catlower][1][schlower][1].values()]
+            else:
+                res = list(self._dbmetadata[obj_type][catlower][1][schlower][1].keys())
 
-        return list(res)
+        if len(res) == 0 and self._conn.connected():
+            # Special case: Look for tables without catalog/schema
+            res = []
+            if catalog == "" and schema == "":
+                res_u = self._conn.find_tables(
+                        catalog = "\x00",
+                        schema = "\x00",
+                        table = "",
+                        type = obj_type)
+            else:
+                res_u = self._conn.find_tables(
+                        catalog = self._conn.sanitize_search_string(
+                            self.unescape_name(catalog)),
+                        schema = self._conn.sanitize_search_string(
+                            self.unescape_name(schema)),
+                        table = "",
+                        type = obj_type)
+            res_u = [r.name for r in res_u]
+            res = self.escape_names(res_u)
+
+            self.extend_objects(
+                    catalog = catalog, schema = schema,
+                    names = res, obj_type = obj_type)
+            # TODO: Should we recursively call get_objects here so as to make
+            # sure we are returning the correct spec
+
+        return res
+
+    def extend_columns(self, catalog, schema, name, cols: list, obj_type: str) -> None:
+        catlower = catalog.lower()
+        schlower = schema.lower()
+        nmlower = name.lower()
+        if len(cols):
+            with self._lock:
+                for otype in self._dbmetadata.keys():
+                    # Loop over tables, views, functions
+                    if catlower not in self._dbmetadata[otype].keys():
+                        self._dbmetadata[otype][catlower] = (catalog, {})
+                    if schlower not in self._dbmetadata[otype][catlower][1].keys():
+                        self._dbmetadata[otype][catlower][1][schlower] = (schema, {})
+                for col in cols:
+                    try:
+                        self._dbmetadata[obj_type][catlower][1][schlower][1][nmlower][1][col.column.lower()] = (col.column, col)
+                    except KeyError:
+                        pass
+        # If we passed nothing then take out that element entirely out
+        # of the dict
+        else:
+            with self._lock:
+                try:
+                    del self._dbmetadata[obj_type][catlower][1][schlower]
+                except KeyError:
+                    pass
+
+        return
+
+    def get_columns(self, catalog: str, schema: str, name: str, obj_type: str = "table") -> list:
+        """
+            Returns a list of named tuples.  See cyanodbc.connection.find_columns
+        """
+        catlower = catalog.lower()
+        schlower = schema.lower()
+        nmlower = name.lower()
+        objs = self.get_objects(catalog = catalog, schema = schema,
+                obj_type = obj_type, cased = False) # TODO add cased argument to get_objects
+        if (objs is None or nmlower not in objs):
+            return None
+
+        res = []
+        with self._lock:
+            res = [mappedvalue for casedkey, mappedvalue in self._dbmetadata[obj_type][catlower][1][schlower][1][nmlower][1].values()]
+
+        if len(res) == 0 and self._conn.connected():
+            # res is a collections.namedtuple object
+            res = self._conn.find_columns(
+                    # Per SQLColumns spec: CatalogName cannot contain a
+                    # string search pattern.  But should we sanitize
+                    # regardless?
+                    catalog = self.unescape_name(catalog),
+                    schema = self._conn.sanitize_search_string(
+                        self.unescape_name(schema)),
+                    table = self._conn.sanitize_search_string(
+                        self.unescape_name(name)),
+                    column = "%")
+
+            self.extend_columns(
+                    catalog = catalog, schema = schema, name = name,
+                    cols = res, obj_type = obj_type)
+            # TODO: Should we recursively call get_columns here so as to make
+            # sure we are returning the correct spec
+
+        return res
 
     def reset_metadata(self) -> None:
         with self._lock:


### PR DESCRIPTION
DbMetadata now better provisioned.  All get_(catalogs | schema | objects
| functions) calls first look to internal representation, and if
information not found there, then they reach out to sql connection.